### PR TITLE
Add log test for tls nvstore example

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Although the board shown in this examples is K64F, the example should work on an
    
  4. Open a serial console session with the target platform using the following parameters:
 
-    * **Baud rate:** 115200
+    * **Baud rate:** 9600
     * **Data bits:** 8
     * **Stop bits:** 1
     * **Parity:** None
@@ -47,9 +47,9 @@ Although the board shown in this examples is K64F, the example should work on an
  6. Press the **RESET** button on the board to run the program
 
  7. The serial console should now display a series of results following the NVStore API invocations. 
- 
+
  8. Unless specifically configured by the user, NVStore selects the last two flash sectors as its areas, with the minimum size of 4KBs. This means that if the sectors are smaller, a few continuous ones will be used for each area.
- 
+
     If the automatically selected sectors do not fit your flash configuration, you can override this by setting the addresses and sizes of both areas in `mbed_lib.json` for each board. 
     
 	Copy `mbed_app-K64F-8KB-areas.json` to `mbed_app.json` and edit `mbed_app.json` to match your board.
@@ -62,7 +62,6 @@ Although the board shown in this examples is K64F, the example should work on an
 	-   `area_1_size`
 	-   `area_2_address`
 	-   `area_2_size`
-	
 	
  9. Repeat steps 3-7. Notice the changes in prints of area addresses and sizes and with the amount of possible keys this configuration can hold.
 

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -1,8 +1,6 @@
 {
     "target_overrides": {
         "*": {
-            "platform.stdio-baud-rate": 115200,
-            "platform.default-serial-baud-rate": 115200,
             "platform.stdio-convert-newlines": 1
         }
     }

--- a/tests/README.md
+++ b/tests/README.md
@@ -8,5 +8,5 @@ mbedhtrun -d D: -p COM4 -m K64F -f .\BUILD\K64F\GCC_ARM\nvstore.bin --compare-lo
 ```
 
 
-More details about `htrun` are [here](https://github.com/ARMmbed/htrun#testing-mbed-os-examples).
+More details about `htrun` are [here](https://github.com/ARMmbed/mbed-os-tools/tree/master/packages/mbed-host-tests#testing-mbed-os-examples).
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,12 @@
+# Testing examples
+
+Examples are tested using tool [htrun](https://github.com/ARMmbed/mbed-os-tools/tree/master/packages/mbed-host-tests) and templated print log. 
+
+To run the test, use following command after you build the example:
+```
+mbedhtrun -d D: -p COM4 -m K64F -f .\BUILD\K64F\GCC_ARM\nvstore.bin --compare-log tests\nvstore.log
+```
+
+
+More details about `htrun` are [here](https://github.com/ARMmbed/htrun#testing-mbed-os-examples).
+

--- a/tests/nvstore.log
+++ b/tests/nvstore.log
@@ -1,0 +1,20 @@
+--- Mbed OS NVStore example ---
+Init NVStore. Return code is 0 \(as expected\).
+NVStore size is \d+.
+NVStore max number of keys is \d+ \(out of 255 possible ones in this flash configuration\).
+NVStore areas:
+Area 0: address 0x[0-9a-fA-F]+, size \d+ \(0x[0-9a-fA-F]+\).
+Area 1: address 0x[0-9a-fA-F]+, size \d+ \(0x[0-9a-fA-F]+\).
+Reset NVStore. Return code is 0 (as expected).
+Set key 1 to value 1000. Return code is 0 \(as expected\).
+Set key 1 to value 2000. Return code is 0 \(as expected\).
+Set key 1 to value 3000. Return code is 0 \(as expected\).
+Get key 1. Value is 3000. Return code is 0 \(as expected\).
+Delete key 1. Return code is 0 \(as expected\).
+Get key 1. Return code is -3 \(as expected\).
+Set key 12 once to value 50. Return code is 0 \(as expected\).
+Set key 12 to value 100. Return code is -9 \(as expected\).
+Get key 12. Value is 50. Return code is 0 \(as expected\).
+Data size for key 12 is 4. Return code is 0 \(as expected\).
+
+--- Mbed OS NVStore example done. ---


### PR DESCRIPTION
Add a log compare test for this example for enable example CI testing
And change default baud rate to 9600 default, 

I don't know if there is any justifiable reason to use the baud rate as 115200, I just change it to 9600 to make it is consistent with other examples, and it is going the make the test easier 